### PR TITLE
feat: add project name uniqueness check early in CreateProjectCommand

### DIFF
--- a/src/main/java/com/preponderous/parpt/command/CreateProjectCommand.java
+++ b/src/main/java/com/preponderous/parpt/command/CreateProjectCommand.java
@@ -63,6 +63,9 @@ public class CreateProjectCommand {
         if (projectName == null || projectName.isEmpty()) {
             return "Project name cannot be empty.";
         }
+        if (projectService.isNameTaken(projectName)) {
+            return "Project name '" + projectName + "' is already taken. Please choose a different name.";
+        }
         if (projectDescription == null) {
             projectDescription = inputProvider.readLine(promptProperties.getProjectDescription());
         }

--- a/src/main/java/com/preponderous/parpt/service/ProjectService.java
+++ b/src/main/java/com/preponderous/parpt/service/ProjectService.java
@@ -35,4 +35,13 @@ public class ProjectService {
     public Project getProject(String projectName) throws ProjectRepository.ProjectNotFoundException {
         return projectRepository.findByName(projectName);
     }
+
+    public boolean isNameTaken(String projectName) {
+        try {
+            getProject(projectName);
+            return true;
+        } catch (ProjectRepository.ProjectNotFoundException e) {
+            return false;
+        }
+    }
 }


### PR DESCRIPTION
Introduce `isNameTaken` method in ProjectService to verify project name availability. Update CreateProjectCommand to prevent creation of projects with duplicate names.