### PR TITLE
Fix documentation drift in README and CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,7 @@ To run the full build (including tests):
 ## Continuous Integration
 This project uses GitHub Actions for continuous integration. All pull requests and pushes to main/develop branches will automatically:
 - Build the project with Java 21
-- Run all unit tests (currently 61 tests)
+- Run all unit tests (currently 58 tests)
 - Generate test reports and artifacts
 - Validate the Gradle wrapper
 
@@ -36,4 +36,4 @@ The CI pipeline ensures code quality by:
 Make sure all tests pass locally before submitting a pull request. The CI checks must pass before merging.
 
 ## License
-By contributing, you agree that your contributions will be licensed under the MIT License.
+By contributing, you agree that your contributions will be licensed under the project's [Stephenson Software Non-Commercial License (Stephenson-NC)](https://github.com/Stephenson-Software/stephenson-nc-license), as described in [LICENSE](LICENSE).

--- a/README.md
+++ b/README.md
@@ -25,14 +25,14 @@ Each project is evaluated across 5 dimensions using a detailed 1-5 scoring syste
 
 ## Installation
 Clone and build manually:
-git clone https://www.github.com/Preponderous/Parpt.git
+git clone https://github.com/Stephenson-Software/Parpt.git
 cd Parpt
 ./gradlew build
-java -jar build/libs/parpt.jar
+java -jar build/libs/Parpt-*.jar
 
 ## Getting Started
 Run the CLI:
-java -jar parpt.jar
+java -jar build/libs/Parpt-*.jar
 
 Available commands:
 - `create` - Create a new project with guided scoring


### PR DESCRIPTION
## Summary

A documentation accuracy sweep was performed against the current source of truth (LICENSE, build.gradle/settings.gradle output, git remote), and three drift points were found and corrected:

- The `git clone` URL in README's Installation section pointed at `Preponderous/Parpt`, an org that does not match the actual remote (`Stephenson-Software/Parpt`) — a new contributor following the steps literally would clone the wrong (or a nonexistent) repository.
- The `java -jar` commands in README's Installation and Getting Started sections referenced `parpt.jar` / `build/libs/parpt.jar`, but the Spring Boot build actually produces `build/libs/Parpt-<version>.jar` (verified by running `./gradlew bootJar` and inspecting `build/libs/`). Both references were updated to the glob form `build/libs/Parpt-*.jar` so the doc does not go stale again on the next version bump.
- CONTRIBUTING's License section stated contributions are licensed under "the MIT License," which conflicts with the repository's actual LICENSE file and the license section of README (Stephenson Software Non-Commercial License). The line was corrected to reference Stephenson-NC and link to LICENSE.
- CONTRIBUTING's CI description cited "currently 61 tests," which no longer matches the actual count (58, confirmed via `grep -rn "@Test" src/test | wc -l`); the figure was updated.

No source/behavior changes are included — this PR is docs-only.

This PR description was drafted during a Gardener session (https://github.com/Stephenson-Software/gardener).

<!-- gardener-tend-dispatch -->

## Test plan
- [x] `./gradlew test` run locally — all 58 tests pass (baseline confirmed unaffected, since only Markdown files were touched)
- [x] `./gradlew bootJar` run locally to confirm the actual jar filename referenced in the corrected README matches real build output
- [x] Every corrected claim (org name, jar filename, license, test count) checked against source (git remote, build/libs/ contents, LICENSE file, test grep) rather than assumed