### PR TITLE
Support sorting in the list command and add an 'ls' alias

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,7 @@ To run the full build (including tests):
 ## Continuous Integration
 This project uses GitHub Actions for continuous integration. All pull requests and pushes to main/develop branches will automatically:
 - Build the project with Java 21
-- Run all unit tests (currently 58 tests)
+- Run all unit tests
 - Generate test reports and artifacts
 - Validate the Gradle wrapper
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ java -jar build/libs/Parpt-*.jar
 
 Available commands:
 - `create` - Create a new project with guided scoring
-- `list` - List all projects with scores
+- `list` (alias: `ls`) - List all projects with scores, optionally sorted
 - `view <project-name>` - View detailed project information
 - `export` - Export all projects to Markdown format
 - `help` - Show available commands
@@ -49,6 +49,25 @@ You'll be prompted to enter:
     - Save the results to `projects.json`
     - Allow you to export to `projects.md` sorted by priority
     - Help you sort and review your efforts over time
+
+### List Examples
+```bash
+# List projects in the order they were created (default)
+list
+
+# The 'ls' alias behaves identically
+ls
+
+# List projects sorted by a score, highest first
+list --sort ice
+list --sort rice
+
+# List projects sorted by name (A to Z) or by any scoring field, highest first
+list --sort name
+list -s impact
+```
+
+Supported `--sort` values are `name`, `impact`, `confidence`, `ease`, `reach`, `effort`, `ice` and `rice`. Every value except `name` sorts from highest to lowest; omitting `--sort` keeps the order in which projects were created.
 
 ### Export Examples
 ```bash

--- a/src/main/java/com/preponderous/parpt/command/ListProjectsCommand.java
+++ b/src/main/java/com/preponderous/parpt/command/ListProjectsCommand.java
@@ -1,33 +1,57 @@
 package com.preponderous.parpt.command;
 
 import com.preponderous.parpt.domain.Project;
+import com.preponderous.parpt.export.ProjectSorter;
 import com.preponderous.parpt.score.ScoreCalculator;
 import com.preponderous.parpt.service.ProjectService;
 import org.springframework.shell.standard.ShellComponent;
 import org.springframework.shell.standard.ShellMethod;
+import org.springframework.shell.standard.ShellOption;
 
 import java.util.List;
+import java.util.Locale;
 
 @ShellComponent
 public class ListProjectsCommand {
 
+    /**
+     * The sort option that leaves projects in the order they were created.
+     */
+    static final String SORT_NONE = "none";
+
     private final ProjectService projectService;
     private final ScoreCalculator scoreCalculator;
+    private final ProjectSorter projectSorter;
 
-    public ListProjectsCommand(ProjectService projectService, ScoreCalculator scoreCalculator) {
+    public ListProjectsCommand(ProjectService projectService, ScoreCalculator scoreCalculator, ProjectSorter projectSorter) {
         this.projectService = projectService;
         this.scoreCalculator = scoreCalculator;
+        this.projectSorter = projectSorter;
     }
 
-    @ShellMethod(key = "list", value = "Lists all projects.")
-    public String execute() {
+    @ShellMethod(key = {"list", "ls"}, value = "Lists all projects, optionally sorted by a chosen field.")
+    public String execute(
+            @ShellOption(value = {"-s", "--sort"}, help = "Sort by 'name', 'impact', 'confidence', 'ease', 'reach', 'effort', 'ice' or 'rice' (default: creation order)", defaultValue = SORT_NONE) String sortBy
+    ) {
         List<Project> projects = projectService.getProjects();
 
         if (projects.isEmpty()) {
             return "No projects found.";
         }
 
-        StringBuilder result = new StringBuilder("Projects:\n");
+        boolean sorted = !SORT_NONE.equalsIgnoreCase(sortBy);
+
+        if (sorted) {
+            if (!ProjectSorter.isSupportedSortKey(sortBy)) {
+                return String.format("Invalid sort option. Use one of: %s (or omit --sort to keep creation order).",
+                        String.join(", ", ProjectSorter.getSupportedSortKeys()));
+            }
+            projects = projectSorter.sortBy(projects, sortBy);
+        }
+
+        StringBuilder result = new StringBuilder(sorted
+                ? String.format("Projects (sorted by %s):\n", sortBy.toLowerCase(Locale.ROOT))
+                : "Projects:\n");
         for (Project project : projects) {
             result.append(String.format("- %s: %s (ICE: %s | RICE: %s)\n", project.getName(), project.getDescription(), scoreCalculator.ice(project), scoreCalculator.rice(project)));
         }

--- a/src/main/java/com/preponderous/parpt/export/ProjectSorter.java
+++ b/src/main/java/com/preponderous/parpt/export/ProjectSorter.java
@@ -6,18 +6,46 @@ import org.springframework.stereotype.Component;
 
 import java.util.Comparator;
 import java.util.List;
+import java.util.Locale;
 
 /**
- * Component responsible for sorting projects by their calculated scores.
- * This separates the sorting logic from the formatting logic.
+ * Component responsible for sorting projects by their calculated scores or by one of
+ * their scoring fields. This separates the sorting logic from the formatting logic.
  */
 @Component
 public class ProjectSorter {
+
+    /**
+     * The sort keys accepted by {@link #sortBy(List, String)}, in the order they are
+     * presented to the user.
+     */
+    private static final List<String> SUPPORTED_SORT_KEYS =
+            List.of("name", "impact", "confidence", "ease", "reach", "effort", "ice", "rice");
 
     private final ScoreCalculator scoreCalculator;
 
     public ProjectSorter(ScoreCalculator scoreCalculator) {
         this.scoreCalculator = scoreCalculator;
+    }
+
+    /**
+     * Returns the sort keys accepted by {@link #sortBy(List, String)}.
+     *
+     * @return an unmodifiable list of supported sort keys
+     */
+    public static List<String> getSupportedSortKeys() {
+        return SUPPORTED_SORT_KEYS;
+    }
+
+    /**
+     * Indicates whether a sort key is accepted by {@link #sortBy(List, String)}.
+     * The comparison is case-insensitive.
+     *
+     * @param sortKey the sort key to check, may be null
+     * @return true if the key is supported
+     */
+    public static boolean isSupportedSortKey(String sortKey) {
+        return sortKey != null && SUPPORTED_SORT_KEYS.contains(sortKey.toLowerCase(Locale.ROOT));
     }
 
     /**
@@ -57,5 +85,45 @@ public class ProjectSorter {
      */
     public List<Project> sortByRice(List<Project> projects) {
         return sortByScore(projects, true);
+    }
+
+    /**
+     * Sorts a list of projects by the given sort key. Projects are ordered by name
+     * alphabetically (case-insensitive, A to Z) and by every other key from highest
+     * to lowest. Projects that compare equal keep their original relative order.
+     *
+     * @param projects the list of projects to sort
+     * @param sortKey one of {@link #getSupportedSortKeys()}, case-insensitive
+     * @return new list with projects sorted by the given key
+     * @throws IllegalArgumentException if the list is null or the sort key is unsupported
+     */
+    public List<Project> sortBy(List<Project> projects, String sortKey) {
+        if (projects == null) {
+            throw new IllegalArgumentException("Projects list cannot be null");
+        }
+
+        return projects.stream()
+                .sorted(comparatorFor(sortKey))
+                .toList();
+    }
+
+    private Comparator<Project> comparatorFor(String sortKey) {
+        if (!isSupportedSortKey(sortKey)) {
+            throw new IllegalArgumentException("Unsupported sort key: " + sortKey
+                    + ". Supported keys: " + String.join(", ", SUPPORTED_SORT_KEYS));
+        }
+
+        return switch (sortKey.toLowerCase(Locale.ROOT)) {
+            case "name" -> Comparator.comparing(Project::getName,
+                    Comparator.nullsLast(String.CASE_INSENSITIVE_ORDER));
+            case "impact" -> Comparator.comparingInt((Project p) -> p.getImpact()).reversed();
+            case "confidence" -> Comparator.comparingInt((Project p) -> p.getConfidence()).reversed();
+            case "ease" -> Comparator.comparingInt((Project p) -> p.getEase()).reversed();
+            case "reach" -> Comparator.comparingInt((Project p) -> p.getReach()).reversed();
+            case "effort" -> Comparator.comparingInt((Project p) -> p.getEffort()).reversed();
+            case "ice" -> Comparator.comparingDouble((Project p) -> scoreCalculator.ice(p)).reversed();
+            case "rice" -> Comparator.comparingDouble((Project p) -> scoreCalculator.rice(p)).reversed();
+            default -> throw new IllegalArgumentException("Unsupported sort key: " + sortKey);
+        };
     }
 }

--- a/src/test/java/com/preponderous/parpt/command/ListProjectsCommandTest.java
+++ b/src/test/java/com/preponderous/parpt/command/ListProjectsCommandTest.java
@@ -1,5 +1,6 @@
 package com.preponderous.parpt.command;
 
+import com.preponderous.parpt.export.ProjectSorter;
 import com.preponderous.parpt.repo.ProjectRepository;
 import com.preponderous.parpt.score.ScoreCalculator;
 import com.preponderous.parpt.service.ProjectService;
@@ -7,7 +8,12 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.shell.standard.ShellMethod;
 
+import java.util.Arrays;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @SpringBootTest
@@ -24,10 +30,13 @@ class ListProjectsCommandTest {
     @Autowired
     ScoreCalculator scoreCalculator;
 
+    @Autowired
+    ProjectSorter projectSorter;
+
     @BeforeEach
     void setUp() {
         // Initialize the command with the project service
-        listProjectsCommand = new ListProjectsCommand(projectService, scoreCalculator);
+        listProjectsCommand = new ListProjectsCommand(projectService, scoreCalculator, projectSorter);
 
         // Clear any existing projects in the repository before each test
         projectRepository.clear();
@@ -38,7 +47,7 @@ class ListProjectsCommandTest {
         // Given no projects exist
 
         // When the command is executed
-        var result = listProjectsCommand.execute();
+        var result = listProjectsCommand.execute(ListProjectsCommand.SORT_NONE);
 
         // Then the result should be an empty list
         assertTrue(result.contains("No projects found."));
@@ -51,11 +60,94 @@ class ListProjectsCommandTest {
         projectService.createProject("Project B", "Description B", 4, 3, 2, 1, 5);
 
         // When the command is executed
-        var result = listProjectsCommand.execute();
+        var result = listProjectsCommand.execute(ListProjectsCommand.SORT_NONE);
 
         // Then the result should contain the projects
         assertTrue(result.contains("Projects:"));
         assertTrue(result.contains("Project A: Description A"));
         assertTrue(result.contains("Project B: Description B"));
+    }
+
+    @Test
+    void shouldPreserveCreationOrderWhenNoSortOptionIsGiven() throws ProjectRepository.NameTakenException {
+        // Given projects are created out of alphabetical and score order
+        projectService.createProject("Zebra", "Created first", 1, 1, 1, 1, 1);
+        projectService.createProject("Apple", "Created second", 5, 5, 5, 5, 1);
+
+        // When the command is executed without a sort option
+        var result = listProjectsCommand.execute(ListProjectsCommand.SORT_NONE);
+
+        // Then the projects appear in creation order and the header is unqualified
+        assertTrue(result.contains("Projects:"));
+        assertTrue(result.indexOf("Zebra") < result.indexOf("Apple"));
+    }
+
+    @Test
+    void shouldSortByNameWhenNameSortIsRequested() throws ProjectRepository.NameTakenException {
+        // Given projects are created out of alphabetical order
+        projectService.createProject("Zebra", "Created first", 1, 1, 1, 1, 1);
+        projectService.createProject("Apple", "Created second", 5, 5, 5, 5, 1);
+
+        // When the command is executed with the name sort option
+        var result = listProjectsCommand.execute("name");
+
+        // Then the projects are listed alphabetically
+        assertTrue(result.contains("Projects (sorted by name):"));
+        assertTrue(result.indexOf("Apple") < result.indexOf("Zebra"));
+    }
+
+    @Test
+    void shouldSortByIceWhenIceSortIsRequested() throws ProjectRepository.NameTakenException {
+        // Given a low-scoring project is created before a high-scoring one
+        projectService.createProject("Low", "Low ICE", 1, 1, 1, 1, 1);
+        projectService.createProject("High", "High ICE", 5, 5, 5, 1, 1);
+
+        // When the command is executed with the ice sort option
+        var result = listProjectsCommand.execute("ice");
+
+        // Then the highest ICE score is listed first
+        assertTrue(result.contains("Projects (sorted by ice):"));
+        assertTrue(result.indexOf("High") < result.indexOf("Low"));
+    }
+
+    @Test
+    void shouldAcceptSortKeyRegardlessOfCase() throws ProjectRepository.NameTakenException {
+        // Given projects are created out of alphabetical order
+        projectService.createProject("Zebra", "Created first", 1, 1, 1, 1, 1);
+        projectService.createProject("Apple", "Created second", 5, 5, 5, 5, 1);
+
+        // When the command is executed with an upper-case sort option
+        var result = listProjectsCommand.execute("NAME");
+
+        // Then the sort is applied and the header reports the key in lower case
+        assertTrue(result.contains("Projects (sorted by name):"));
+        assertTrue(result.indexOf("Apple") < result.indexOf("Zebra"));
+    }
+
+    @Test
+    void shouldRejectUnsupportedSortKey() throws ProjectRepository.NameTakenException {
+        // Given a project exists
+        projectService.createProject("Project A", "Description A", 5, 4, 3, 2, 1);
+
+        // When the command is executed with an unsupported sort option
+        var result = listProjectsCommand.execute("bogus");
+
+        // Then an error naming the supported options is returned and nothing is listed
+        assertTrue(result.contains("Invalid sort option."));
+        assertTrue(result.contains("name, impact, confidence, ease, reach, effort, ice, rice"));
+        assertFalse(result.contains("Project A: Description A"));
+    }
+
+    @Test
+    void shouldExposeLsAsAnAliasForTheListCommand() throws NoSuchMethodException {
+        // Given the shell method backing the list command
+        ShellMethod shellMethod = ListProjectsCommand.class
+                .getMethod("execute", String.class)
+                .getAnnotation(ShellMethod.class);
+
+        // Then both the primary key and the alias are registered
+        assertEquals(2, shellMethod.key().length);
+        assertTrue(Arrays.asList(shellMethod.key()).contains("list"));
+        assertTrue(Arrays.asList(shellMethod.key()).contains("ls"));
     }
 }

--- a/src/test/java/com/preponderous/parpt/export/ProjectSorterTest.java
+++ b/src/test/java/com/preponderous/parpt/export/ProjectSorterTest.java
@@ -189,6 +189,152 @@ class ProjectSorterTest {
     }
 
     @Test
+    void sortBy_WithNullProjects_ShouldThrowException() {
+        // When & Then
+        assertThrows(IllegalArgumentException.class,
+                () -> projectSorter.sortBy(null, "name"));
+    }
+
+    @Test
+    void sortBy_WithUnsupportedKey_ShouldThrowException() {
+        // Given
+        List<Project> projects = List.of(Project.builder().name("Project 1").build());
+
+        // When & Then
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+                () -> projectSorter.sortBy(projects, "bogus"));
+        assertTrue(exception.getMessage().contains("bogus"));
+    }
+
+    @Test
+    void sortBy_WithName_ShouldSortAlphabeticallyIgnoringCase() {
+        // Given
+        Project project1 = Project.builder().name("zebra").build();
+        Project project2 = Project.builder().name("Apple").build();
+        Project project3 = Project.builder().name("mango").build();
+        List<Project> projects = Arrays.asList(project1, project2, project3);
+
+        // When
+        List<Project> result = projectSorter.sortBy(projects, "name");
+
+        // Then
+        assertEquals("Apple", result.get(0).getName());
+        assertEquals("mango", result.get(1).getName());
+        assertEquals("zebra", result.get(2).getName());
+        verify(scoreCalculator, never()).ice(any());
+        verify(scoreCalculator, never()).rice(any());
+    }
+
+    @Test
+    void sortBy_WithImpact_ShouldSortHighestFirst() {
+        // Given
+        Project project1 = Project.builder().name("Low impact").impact(1).build();
+        Project project2 = Project.builder().name("High impact").impact(5).build();
+        Project project3 = Project.builder().name("Medium impact").impact(3).build();
+        List<Project> projects = Arrays.asList(project1, project2, project3);
+
+        // When
+        List<Project> result = projectSorter.sortBy(projects, "impact");
+
+        // Then
+        assertEquals("High impact", result.get(0).getName());
+        assertEquals("Medium impact", result.get(1).getName());
+        assertEquals("Low impact", result.get(2).getName());
+    }
+
+    @Test
+    void sortBy_WithEffort_ShouldSortHighestFirst() {
+        // Given
+        Project project1 = Project.builder().name("Low effort").effort(2).build();
+        Project project2 = Project.builder().name("High effort").effort(8).build();
+        List<Project> projects = Arrays.asList(project1, project2);
+
+        // When
+        List<Project> result = projectSorter.sortBy(projects, "effort");
+
+        // Then
+        assertEquals("High effort", result.get(0).getName());
+        assertEquals("Low effort", result.get(1).getName());
+    }
+
+    @Test
+    void sortBy_WithRice_ShouldSortByRiceScore() {
+        // Given
+        Project project1 = Project.builder().name("Low RICE").build();
+        Project project2 = Project.builder().name("High RICE").build();
+        List<Project> projects = Arrays.asList(project1, project2);
+        when(scoreCalculator.rice(project1)).thenReturn(5.0);
+        when(scoreCalculator.rice(project2)).thenReturn(25.0);
+
+        // When
+        List<Project> result = projectSorter.sortBy(projects, "rice");
+
+        // Then
+        assertEquals("High RICE", result.get(0).getName());
+        assertEquals("Low RICE", result.get(1).getName());
+        verify(scoreCalculator, never()).ice(any());
+    }
+
+    @Test
+    void sortBy_WithMixedCaseKey_ShouldSortAsIfLowerCase() {
+        // Given
+        Project project1 = Project.builder().name("Low ICE").build();
+        Project project2 = Project.builder().name("High ICE").build();
+        List<Project> projects = Arrays.asList(project1, project2);
+        when(scoreCalculator.ice(project1)).thenReturn(10.0);
+        when(scoreCalculator.ice(project2)).thenReturn(50.0);
+
+        // When
+        List<Project> result = projectSorter.sortBy(projects, "IcE");
+
+        // Then
+        assertEquals("High ICE", result.get(0).getName());
+        assertEquals("Low ICE", result.get(1).getName());
+    }
+
+    @Test
+    void sortBy_ShouldNotModifyOriginalList() {
+        // Given
+        Project project1 = Project.builder().name("Zebra").build();
+        Project project2 = Project.builder().name("Apple").build();
+        List<Project> originalProjects = Arrays.asList(project1, project2);
+
+        // When
+        List<Project> sortedProjects = projectSorter.sortBy(originalProjects, "name");
+
+        // Then
+        assertEquals("Zebra", originalProjects.get(0).getName());
+        assertEquals("Apple", sortedProjects.get(0).getName());
+        assertNotSame(originalProjects, sortedProjects);
+    }
+
+    @Test
+    void isSupportedSortKey_ShouldAcceptEverySupportedKeyIgnoringCase() {
+        // Given & When & Then
+        for (String key : ProjectSorter.getSupportedSortKeys()) {
+            assertTrue(ProjectSorter.isSupportedSortKey(key));
+            assertTrue(ProjectSorter.isSupportedSortKey(key.toUpperCase()));
+        }
+    }
+
+    @Test
+    void isSupportedSortKey_WithUnknownOrNullKey_ShouldReturnFalse() {
+        // When & Then
+        assertFalse(ProjectSorter.isSupportedSortKey("bogus"));
+        assertFalse(ProjectSorter.isSupportedSortKey(null));
+        assertFalse(ProjectSorter.isSupportedSortKey("none"));
+    }
+
+    @Test
+    void getSupportedSortKeys_ShouldListEveryScoringFieldAndScore() {
+        // When
+        List<String> keys = ProjectSorter.getSupportedSortKeys();
+
+        // Then
+        assertEquals(List.of("name", "impact", "confidence", "ease", "reach", "effort", "ice", "rice"), keys);
+    }
+
+    @Test
     void sortByScore_WithSingleProject_ShouldReturnSingleProjectList() {
         // Given
         Project project = Project.builder().name("Only Project").build();


### PR DESCRIPTION
<!-- gardener-tend-dispatch -->

## Summary

- A `--sort` / `-s` option has been added to the `list` command. Supported values are `name`, `impact`, `confidence`, `ease`, `reach`, `effort`, `ice` and `rice`; matching is case-insensitive.
- Sorting is delegated to a new `ProjectSorter.sortBy(List<Project>, String)` method, so the existing sorting component is reused rather than duplicated. `name` is ordered alphabetically (case-insensitive, A to Z); every other key is ordered highest to lowest, matching the existing score-sorting behavior used by the `export` command.
- Existing behavior has been preserved: when `--sort` is omitted, projects are still listed in creation order and the header remains `Projects:`. When a sort is applied, the header reports it as `Projects (sorted by <key>):`.
- An unsupported sort value is rejected with a message naming every supported value, following the error style already used by `ExportProjectsCommand`.
- `ls` has been registered as an alias for `list` via the `@ShellMethod` key array.
- `README.md` has been updated with the alias, a List Examples block, and the supported sort values. A hardcoded test count in `CONTRIBUTING.md` was found to be stale and has been replaced with a non-brittle statement, since this PR changes that count again.

## Test plan

- [x] `./gradlew test` passes locally (78 tests).
- [x] `ProjectSorterTest` covers the new `sortBy` method: null list, unsupported key, name ordering, integer-field ordering (`impact`, `effort`), RICE ordering, mixed-case keys, original-list immutability, and the `isSupportedSortKey` / `getSupportedSortKeys` helpers.
- [x] `ListProjectsCommandTest` covers creation-order preservation, `name` sorting, `ice` sorting, case-insensitive keys, rejection of an unsupported key, and registration of the `ls` alias.
- [x] Existing `ProjectSorter` and `export` behavior is untouched; the pre-existing `sortByScore` / `sortByIce` / `sortByRice` tests still pass unchanged.

## Deferred issues

The remaining open backlog was not selected for this cycle, for the reasons below:

- #37 (quit early during project creation) — the interactive creation input flow is a separate subsystem from listing.
- #36 (Linux installation script) — packaging work, unrelated to this batch.
- #33 (save data to the user's home directory) — modifies `src/main/resources/application.yaml`, a path that is gated for human review.
- #32 (create the JSON storage directory if missing) — storage-layer work that pairs naturally with #33 and is better done alongside it.
- #27 (controller endpoints) — introduces a web layer; too large for a polish-sized PR.
- #21 (update command) and #20 (delete command) — each is its own command-plus-persistence change.
- #8 (input validation with Jakarta) — requires a new dependency in `build.gradle`, a path that is gated for human review.

Closes #29
Closes #34

This PR description was drafted during a Gardener session (https://github.com/Stephenson-Software/gardener).