### PR TITLE
Converge export sorting onto the key-based ProjectSorter.sortBy API

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Parpt is an interactive CLI tool that helps developers, indie creators and teams
 - Calculate ICE (Impact, Confidence, Ease) scores
 - Calculate RICE (Reach, Impact, Confidence, Effort) scores
 - Export projects to Markdown and JSON formats
-- Obsidian-compatible markdown export with sorting by ICE/RICE scores
+- Obsidian-compatible markdown export with sorting by name, any scoring field or ICE/RICE scores
 - Rank and sort projects by monetization, potential, feasibility and effort
 - Spring Boot architecture with interactive shell
 - 100% local-first and open source
@@ -38,7 +38,7 @@ Available commands:
 - `create` - Create a new project with guided scoring
 - `list` (alias: `ls`) - List all projects with scores, optionally sorted
 - `view <project-name>` - View detailed project information
-- `export` - Export all projects to Markdown format
+- `export` - Export all projects to Markdown format, optionally sorted
 - `help` - Show available commands
 
 You'll be prompted to enter:
@@ -76,7 +76,13 @@ export
 
 # Export projects sorted by RICE score
 export --sort rice
+
+# Export projects sorted by name (A to Z) or by any scoring field, highest first
+export --sort name
+export -s impact
 ```
+
+`export` accepts the same `--sort` values as `list`: `name`, `impact`, `confidence`, `ease`, `reach`, `effort`, `ice` and `rice`. Every value except `name` sorts from highest to lowest, and the chosen order is recorded in the exported file's header. Unlike `list`, `export` always sorts — omitting `--sort` sorts by ICE score.
 
 ## Roadmap
 - [x] Project input and validation loop

--- a/src/main/java/com/preponderous/parpt/command/ExportProjectsCommand.java
+++ b/src/main/java/com/preponderous/parpt/command/ExportProjectsCommand.java
@@ -1,6 +1,7 @@
 package com.preponderous.parpt.command;
 
 import com.preponderous.parpt.domain.Project;
+import com.preponderous.parpt.export.ProjectSorter;
 import com.preponderous.parpt.repo.ProjectMarkdownWriter;
 import com.preponderous.parpt.service.ProjectService;
 import org.springframework.shell.standard.ShellComponent;
@@ -20,9 +21,9 @@ public class ExportProjectsCommand {
         this.markdownWriter = markdownWriter;
     }
 
-    @ShellMethod(key = "export", value = "Exports all projects to Markdown format, sorted by score.")
+    @ShellMethod(key = "export", value = "Exports all projects to Markdown format, sorted by a chosen field.")
     public String execute(
-            @ShellOption(value = {"-s", "--sort"}, help = "Sort by 'ice' or 'rice' score (default: ice)", defaultValue = "ice") String sortBy
+            @ShellOption(value = {"-s", "--sort"}, help = "Sort by 'name', 'impact', 'confidence', 'ease', 'reach', 'effort', 'ice' or 'rice' (default: ice)", defaultValue = ProjectSorter.DEFAULT_SORT_KEY) String sortBy
     ) {
         List<Project> projects = projectService.getProjects();
 
@@ -30,17 +31,15 @@ public class ExportProjectsCommand {
             return "No projects found to export.";
         }
 
-        boolean sortByRice = "rice".equalsIgnoreCase(sortBy);
-        
-        if (!sortByRice && !"ice".equalsIgnoreCase(sortBy)) {
-            return "Invalid sort option. Use 'ice' or 'rice'.";
+        if (!ProjectSorter.isSupportedSortKey(sortBy)) {
+            return String.format("Invalid sort option. Use one of: %s.",
+                    String.join(", ", ProjectSorter.getSupportedSortKeys()));
         }
 
         try {
-            markdownWriter.writeMarkdown(projects, sortByRice);
-            String scoreType = sortByRice ? "RICE" : "ICE";
-            return String.format("Successfully exported %d projects to projects.md, sorted by %s score.", 
-                    projects.size(), scoreType);
+            markdownWriter.writeMarkdown(projects, sortBy);
+            return String.format("Successfully exported %d projects to projects.md, sorted by %s.",
+                    projects.size(), ProjectSorter.describeSortKey(sortBy));
         } catch (Exception e) {
             return "Failed to export projects: " + e.getMessage();
         }

--- a/src/main/java/com/preponderous/parpt/export/MarkdownFormatter.java
+++ b/src/main/java/com/preponderous/parpt/export/MarkdownFormatter.java
@@ -25,19 +25,20 @@ public class MarkdownFormatter {
     /**
      * Generates the markdown header with timestamp and sorting information.
      *
-     * @param sortByRice true if sorted by RICE, false if sorted by ICE
+     * @param sortKey one of {@link ProjectSorter#getSupportedSortKeys()}, case-insensitive
      * @return formatted header string
+     * @throws IllegalArgumentException if the sort key is unsupported
      */
-    public String formatHeader(boolean sortByRice) {
+    public String formatHeader(String sortKey) {
         StringBuilder header = new StringBuilder();
         header.append("# Project Priorities\n\n");
         header.append("*Generated on ")
               .append(LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")))
               .append("*\n\n");
-        
-        String scoreType = sortByRice ? "RICE" : "ICE";
-        header.append("*Sorted by ").append(scoreType).append(" score (highest to lowest)*\n\n");
-        
+
+        header.append("*Sorted by ").append(ProjectSorter.describeSortKey(sortKey))
+              .append(" (").append(ProjectSorter.describeSortDirection(sortKey)).append(")*\n\n");
+
         return header.toString();
     }
 

--- a/src/main/java/com/preponderous/parpt/export/ProjectSorter.java
+++ b/src/main/java/com/preponderous/parpt/export/ProjectSorter.java
@@ -22,6 +22,13 @@ public class ProjectSorter {
     private static final List<String> SUPPORTED_SORT_KEYS =
             List.of("name", "impact", "confidence", "ease", "reach", "effort", "ice", "rice");
 
+    /**
+     * The sort key applied when the caller does not choose one.
+     */
+    public static final String DEFAULT_SORT_KEY = "ice";
+
+    private static final String NAME_SORT_KEY = "name";
+
     private final ScoreCalculator scoreCalculator;
 
     public ProjectSorter(ScoreCalculator scoreCalculator) {
@@ -49,22 +56,31 @@ public class ProjectSorter {
     }
 
     /**
-     * Sorts a list of projects by their calculated scores.
+     * Describes a sort key as it is presented to the user, e.g. "ICE score" for
+     * {@code ice} and "impact" for {@code impact}.
      *
-     * @param projects the list of projects to sort
-     * @param sortByRice true to sort by RICE score, false to sort by ICE score
-     * @return new list with projects sorted by score (highest to lowest)
+     * @param sortKey one of {@link #getSupportedSortKeys()}, case-insensitive
+     * @return a human-readable description of the sort key
+     * @throws IllegalArgumentException if the sort key is unsupported
      */
-    public List<Project> sortByScore(List<Project> projects, boolean sortByRice) {
-        if (projects == null) {
-            throw new IllegalArgumentException("Projects list cannot be null");
-        }
+    public static String describeSortKey(String sortKey) {
+        String key = requireSupportedSortKey(sortKey);
+        return switch (key) {
+            case "ice", "rice" -> key.toUpperCase(Locale.ROOT) + " score";
+            default -> key;
+        };
+    }
 
-        return projects.stream()
-                .sorted(sortByRice ? 
-                    Comparator.comparingDouble((Project p) -> scoreCalculator.rice(p)).reversed() :
-                    Comparator.comparingDouble((Project p) -> scoreCalculator.ice(p)).reversed())
-                .toList();
+    /**
+     * Describes the direction in which a sort key orders projects, e.g. "A to Z" for
+     * {@code name} and "highest to lowest" for every other key.
+     *
+     * @param sortKey one of {@link #getSupportedSortKeys()}, case-insensitive
+     * @return a human-readable description of the sort direction
+     * @throws IllegalArgumentException if the sort key is unsupported
+     */
+    public static String describeSortDirection(String sortKey) {
+        return NAME_SORT_KEY.equals(requireSupportedSortKey(sortKey)) ? "A to Z" : "highest to lowest";
     }
 
     /**
@@ -74,7 +90,7 @@ public class ProjectSorter {
      * @return new list with projects sorted by ICE score
      */
     public List<Project> sortByIce(List<Project> projects) {
-        return sortByScore(projects, false);
+        return sortBy(projects, "ice");
     }
 
     /**
@@ -84,7 +100,7 @@ public class ProjectSorter {
      * @return new list with projects sorted by RICE score
      */
     public List<Project> sortByRice(List<Project> projects) {
-        return sortByScore(projects, true);
+        return sortBy(projects, "rice");
     }
 
     /**
@@ -107,14 +123,18 @@ public class ProjectSorter {
                 .toList();
     }
 
-    private Comparator<Project> comparatorFor(String sortKey) {
+    private static String requireSupportedSortKey(String sortKey) {
         if (!isSupportedSortKey(sortKey)) {
             throw new IllegalArgumentException("Unsupported sort key: " + sortKey
                     + ". Supported keys: " + String.join(", ", SUPPORTED_SORT_KEYS));
         }
 
-        return switch (sortKey.toLowerCase(Locale.ROOT)) {
-            case "name" -> Comparator.comparing(Project::getName,
+        return sortKey.toLowerCase(Locale.ROOT);
+    }
+
+    private Comparator<Project> comparatorFor(String sortKey) {
+        return switch (requireSupportedSortKey(sortKey)) {
+            case NAME_SORT_KEY -> Comparator.comparing(Project::getName,
                     Comparator.nullsLast(String.CASE_INSENSITIVE_ORDER));
             case "impact" -> Comparator.comparingInt((Project p) -> p.getImpact()).reversed();
             case "confidence" -> Comparator.comparingInt((Project p) -> p.getConfidence()).reversed();

--- a/src/main/java/com/preponderous/parpt/repo/ProjectMarkdownWriter.java
+++ b/src/main/java/com/preponderous/parpt/repo/ProjectMarkdownWriter.java
@@ -1,6 +1,7 @@
 package com.preponderous.parpt.repo;
 
 import com.preponderous.parpt.domain.Project;
+import com.preponderous.parpt.export.ProjectSorter;
 
 import java.util.List;
 
@@ -12,12 +13,12 @@ import java.util.List;
 public interface ProjectMarkdownWriter {
     /**
      * Writes a list of projects to Markdown format.
-     * Projects should be sorted by their calculated scores.
+     * Projects are sorted by the given sort key before being written.
      *
      * @param projects the list of projects to be written to Markdown
-     * @param sortByRice true to sort by RICE score, false to sort by ICE score
+     * @param sortKey one of {@link ProjectSorter#getSupportedSortKeys()}, case-insensitive
      */
-    void writeMarkdown(List<Project> projects, boolean sortByRice);
+    void writeMarkdown(List<Project> projects, String sortKey);
 
     /**
      * Writes a list of projects to Markdown format.
@@ -26,6 +27,6 @@ public interface ProjectMarkdownWriter {
      * @param projects the list of projects to be written to Markdown
      */
     default void writeMarkdown(List<Project> projects) {
-        writeMarkdown(projects, false);
+        writeMarkdown(projects, ProjectSorter.DEFAULT_SORT_KEY);
     }
 }

--- a/src/main/java/com/preponderous/parpt/repo/ProjectMarkdownWriterImpl.java
+++ b/src/main/java/com/preponderous/parpt/repo/ProjectMarkdownWriterImpl.java
@@ -27,22 +27,23 @@ public class ProjectMarkdownWriterImpl implements ProjectMarkdownWriter {
     }
 
     @Override
-    public void writeMarkdown(List<Project> projects, boolean sortByRice) {
+    public void writeMarkdown(List<Project> projects, String sortKey) {
         if (projects == null) {
             throw new IllegalArgumentException("Projects list cannot be null");
         }
 
+        // Sort up front so an unsupported sort key is rejected before the file is touched
+        List<Project> sortedProjects = projectSorter.sortBy(projects, sortKey);
+
         try (FileWriter writer = new FileWriter(markdownFilePath)) {
             // Write header
-            writer.write(markdownFormatter.formatHeader(sortByRice));
-            
-            if (projects.isEmpty()) {
+            writer.write(markdownFormatter.formatHeader(sortKey));
+
+            if (sortedProjects.isEmpty()) {
                 writer.write(markdownFormatter.formatNoProjectsMessage());
                 return;
             }
 
-            // Sort projects and write them
-            List<Project> sortedProjects = projectSorter.sortByScore(projects, sortByRice);
             for (int i = 0; i < sortedProjects.size(); i++) {
                 Project project = sortedProjects.get(i);
                 writer.write(markdownFormatter.formatProject(project, i + 1));

--- a/src/test/java/com/preponderous/parpt/command/ExportProjectsCommandTest.java
+++ b/src/test/java/com/preponderous/parpt/command/ExportProjectsCommandTest.java
@@ -47,9 +47,9 @@ class ExportProjectsCommandTest {
         String result = exportCommand.execute("ice");
 
         // Then
-        verify(markdownWriter).writeMarkdown(projects, false);
+        verify(markdownWriter).writeMarkdown(projects, "ice");
         assertTrue(result.contains("Successfully exported 2 projects"));
-        assertTrue(result.contains("ICE score"));
+        assertTrue(result.contains("sorted by ICE score."));
     }
 
     @Test
@@ -64,9 +64,26 @@ class ExportProjectsCommandTest {
         String result = exportCommand.execute("rice");
 
         // Then
-        verify(markdownWriter).writeMarkdown(projects, true);
+        verify(markdownWriter).writeMarkdown(projects, "rice");
         assertTrue(result.contains("Successfully exported 1 projects"));
-        assertTrue(result.contains("RICE score"));
+        assertTrue(result.contains("sorted by RICE score."));
+    }
+
+    @Test
+    void execute_WithNonScoreSortKey_ShouldExportWithThatKey() {
+        // Given
+        List<Project> projects = List.of(
+                Project.builder().name("Project 1").description("Desc 1").build()
+        );
+        when(projectService.getProjects()).thenReturn(projects);
+
+        // When
+        String result = exportCommand.execute("name");
+
+        // Then
+        verify(markdownWriter).writeMarkdown(projects, "name");
+        assertTrue(result.contains("Successfully exported 1 projects"));
+        assertTrue(result.contains("sorted by name."));
     }
 
     @Test
@@ -78,7 +95,7 @@ class ExportProjectsCommandTest {
         String result = exportCommand.execute("ice");
 
         // Then
-        verify(markdownWriter, never()).writeMarkdown(any(), anyBoolean());
+        verify(markdownWriter, never()).writeMarkdown(any(), anyString());
         assertEquals("No projects found to export.", result);
     }
 
@@ -94,8 +111,8 @@ class ExportProjectsCommandTest {
         String result = exportCommand.execute("invalid");
 
         // Then
-        verify(markdownWriter, never()).writeMarkdown(any(), anyBoolean());
-        assertEquals("Invalid sort option. Use 'ice' or 'rice'.", result);
+        verify(markdownWriter, never()).writeMarkdown(any(), anyString());
+        assertEquals("Invalid sort option. Use one of: name, impact, confidence, ease, reach, effort, ice, rice.", result);
     }
 
     @Test
@@ -105,7 +122,7 @@ class ExportProjectsCommandTest {
                 Project.builder().name("Project 1").description("Desc 1").build()
         );
         when(projectService.getProjects()).thenReturn(projects);
-        doThrow(new RuntimeException("Write failed")).when(markdownWriter).writeMarkdown(any(), anyBoolean());
+        doThrow(new RuntimeException("Write failed")).when(markdownWriter).writeMarkdown(any(), anyString());
 
         // When
         String result = exportCommand.execute("ice");
@@ -123,13 +140,17 @@ class ExportProjectsCommandTest {
         when(projectService.getProjects()).thenReturn(projects);
 
         // When & Then
-        exportCommand.execute("ICE");
-        verify(markdownWriter).writeMarkdown(projects, false);
+        // The key is passed through as given; ProjectSorter and MarkdownFormatter normalize it
+        String upperCaseIceResult = exportCommand.execute("ICE");
+        verify(markdownWriter).writeMarkdown(projects, "ICE");
+        assertTrue(upperCaseIceResult.contains("sorted by ICE score."));
 
-        exportCommand.execute("Rice");
-        verify(markdownWriter).writeMarkdown(projects, true);
+        String mixedCaseRiceResult = exportCommand.execute("Rice");
+        verify(markdownWriter).writeMarkdown(projects, "Rice");
+        assertTrue(mixedCaseRiceResult.contains("sorted by RICE score."));
 
-        exportCommand.execute("RICE");
-        verify(markdownWriter, times(2)).writeMarkdown(projects, true);
+        String mixedCaseNameResult = exportCommand.execute("NaMe");
+        verify(markdownWriter).writeMarkdown(projects, "NaMe");
+        assertTrue(mixedCaseNameResult.contains("sorted by name."));
     }
 }

--- a/src/test/java/com/preponderous/parpt/export/MarkdownFormatterTest.java
+++ b/src/test/java/com/preponderous/parpt/export/MarkdownFormatterTest.java
@@ -30,13 +30,13 @@ class MarkdownFormatterTest {
     @Test
     void formatHeader_WithICESort_ShouldIncludeICEInHeader() {
         // When
-        String header = markdownFormatter.formatHeader(false);
+        String header = markdownFormatter.formatHeader("ice");
 
         // Then
         assertAll(
                 () -> assertTrue(header.contains("# Project Priorities")),
                 () -> assertTrue(header.contains("Generated on")),
-                () -> assertTrue(header.contains("Sorted by ICE score")),
+                () -> assertTrue(header.contains("Sorted by ICE score (highest to lowest)")),
                 () -> assertFalse(header.contains("Sorted by RICE score"))
         );
     }
@@ -44,21 +44,58 @@ class MarkdownFormatterTest {
     @Test
     void formatHeader_WithRICESort_ShouldIncludeRICEInHeader() {
         // When
-        String header = markdownFormatter.formatHeader(true);
+        String header = markdownFormatter.formatHeader("rice");
 
         // Then
         assertAll(
                 () -> assertTrue(header.contains("# Project Priorities")),
                 () -> assertTrue(header.contains("Generated on")),
-                () -> assertTrue(header.contains("Sorted by RICE score")),
+                () -> assertTrue(header.contains("Sorted by RICE score (highest to lowest)")),
                 () -> assertFalse(header.contains("Sorted by ICE score"))
         );
     }
 
     @Test
+    void formatHeader_WithNameSort_ShouldDescribeAlphabeticalOrder() {
+        // When
+        String header = markdownFormatter.formatHeader("name");
+
+        // Then
+        assertAll(
+                () -> assertTrue(header.contains("# Project Priorities")),
+                () -> assertTrue(header.contains("Sorted by name (A to Z)")),
+                () -> assertFalse(header.contains("highest to lowest"))
+        );
+    }
+
+    @Test
+    void formatHeader_WithScoringFieldSort_ShouldDescribeDescendingOrder() {
+        // When
+        String header = markdownFormatter.formatHeader("impact");
+
+        // Then
+        assertTrue(header.contains("Sorted by impact (highest to lowest)"));
+    }
+
+    @Test
+    void formatHeader_WithMixedCaseSortKey_ShouldFormatAsIfLowerCase() {
+        // When
+        String header = markdownFormatter.formatHeader("RiCe");
+
+        // Then
+        assertTrue(header.contains("Sorted by RICE score (highest to lowest)"));
+    }
+
+    @Test
+    void formatHeader_WithUnsupportedSortKey_ShouldThrowException() {
+        // When & Then
+        assertThrows(IllegalArgumentException.class, () -> markdownFormatter.formatHeader("bogus"));
+    }
+
+    @Test
     void formatHeader_ShouldIncludeTimestamp() {
         // When
-        String header = markdownFormatter.formatHeader(false);
+        String header = markdownFormatter.formatHeader("ice");
 
         // Then
         assertTrue(header.contains("Generated on"));

--- a/src/test/java/com/preponderous/parpt/export/ProjectSorterTest.java
+++ b/src/test/java/com/preponderous/parpt/export/ProjectSorterTest.java
@@ -29,26 +29,19 @@ class ProjectSorterTest {
     }
 
     @Test
-    void sortByScore_WithNullProjects_ShouldThrowException() {
-        // When & Then
-        assertThrows(IllegalArgumentException.class, 
-                () -> projectSorter.sortByScore(null, false));
-    }
-
-    @Test
-    void sortByScore_WithEmptyList_ShouldReturnEmptyList() {
+    void sortBy_WithEmptyList_ShouldReturnEmptyList() {
         // Given
         List<Project> emptyList = Collections.emptyList();
 
         // When
-        List<Project> result = projectSorter.sortByScore(emptyList, false);
+        List<Project> result = projectSorter.sortBy(emptyList, "ice");
 
         // Then
         assertTrue(result.isEmpty());
     }
 
     @Test
-    void sortByScore_WithICESorting_ShouldSortByICEScore() {
+    void sortBy_WithIce_ShouldSortByICEScore() {
         // Given
         Project project1 = Project.builder().name("Low ICE").build();
         Project project2 = Project.builder().name("High ICE").build();
@@ -61,14 +54,14 @@ class ProjectSorterTest {
         when(scoreCalculator.ice(project3)).thenReturn(30.0);
 
         // When
-        List<Project> result = projectSorter.sortByScore(projects, false);
+        List<Project> result = projectSorter.sortBy(projects, "ice");
 
         // Then
         assertEquals(3, result.size());
         assertEquals("High ICE", result.get(0).getName());
         assertEquals("Medium ICE", result.get(1).getName());
         assertEquals("Low ICE", result.get(2).getName());
-        
+
         verify(scoreCalculator, atLeastOnce()).ice(project1);
         verify(scoreCalculator, atLeastOnce()).ice(project2);
         verify(scoreCalculator, atLeastOnce()).ice(project3);
@@ -76,35 +69,7 @@ class ProjectSorterTest {
     }
 
     @Test
-    void sortByScore_WithRICESorting_ShouldSortByRICEScore() {
-        // Given
-        Project project1 = Project.builder().name("Low RICE").build();
-        Project project2 = Project.builder().name("High RICE").build();
-        Project project3 = Project.builder().name("Medium RICE").build();
-        
-        List<Project> projects = Arrays.asList(project1, project2, project3);
-        
-        when(scoreCalculator.rice(project1)).thenReturn(5.0);
-        when(scoreCalculator.rice(project2)).thenReturn(25.0);
-        when(scoreCalculator.rice(project3)).thenReturn(15.0);
-
-        // When
-        List<Project> result = projectSorter.sortByScore(projects, true);
-
-        // Then
-        assertEquals(3, result.size());
-        assertEquals("High RICE", result.get(0).getName());
-        assertEquals("Medium RICE", result.get(1).getName());
-        assertEquals("Low RICE", result.get(2).getName());
-        
-        verify(scoreCalculator, atLeastOnce()).rice(project1);
-        verify(scoreCalculator, atLeastOnce()).rice(project2);
-        verify(scoreCalculator, atLeastOnce()).rice(project3);
-        verify(scoreCalculator, never()).ice(any());
-    }
-
-    @Test
-    void sortByScore_WithEqualScores_ShouldMaintainStableOrder() {
+    void sortBy_WithEqualScores_ShouldMaintainStableOrder() {
         // Given
         Project project1 = Project.builder().name("First").build();
         Project project2 = Project.builder().name("Second").build();
@@ -115,7 +80,7 @@ class ProjectSorterTest {
         when(scoreCalculator.ice(project2)).thenReturn(20.0);
 
         // When
-        List<Project> result = projectSorter.sortByScore(projects, false);
+        List<Project> result = projectSorter.sortBy(projects, "ice");
 
         // Then
         assertEquals(2, result.size());
@@ -125,29 +90,7 @@ class ProjectSorterTest {
     }
 
     @Test
-    void sortByScore_ShouldNotModifyOriginalList() {
-        // Given
-        Project project1 = Project.builder().name("Project 1").build();
-        Project project2 = Project.builder().name("Project 2").build();
-        
-        List<Project> originalProjects = Arrays.asList(project1, project2);
-        
-        when(scoreCalculator.ice(project1)).thenReturn(10.0);
-        when(scoreCalculator.ice(project2)).thenReturn(20.0);
-
-        // When
-        List<Project> sortedProjects = projectSorter.sortByScore(originalProjects, false);
-
-        // Then
-        assertEquals("Project 1", originalProjects.get(0).getName());
-        assertEquals("Project 2", originalProjects.get(1).getName());
-        assertEquals("Project 2", sortedProjects.get(0).getName());
-        assertEquals("Project 1", sortedProjects.get(1).getName());
-        assertNotSame(originalProjects, sortedProjects);
-    }
-
-    @Test
-    void sortByIce_ShouldDelegateToSortByScoreWithFalse() {
+    void sortByIce_ShouldDelegateToSortByWithIceKey() {
         // Given
         Project project1 = Project.builder().name("Project 1").build();
         Project project2 = Project.builder().name("Project 2").build();
@@ -168,7 +111,7 @@ class ProjectSorterTest {
     }
 
     @Test
-    void sortByRice_ShouldDelegateToSortByScoreWithTrue() {
+    void sortByRice_ShouldDelegateToSortByWithRiceKey() {
         // Given
         Project project1 = Project.builder().name("Project 1").build();
         Project project2 = Project.builder().name("Project 2").build();
@@ -335,16 +278,64 @@ class ProjectSorterTest {
     }
 
     @Test
-    void sortByScore_WithSingleProject_ShouldReturnSingleProjectList() {
+    void sortBy_WithSingleProject_ShouldReturnSingleProjectList() {
         // Given
         Project project = Project.builder().name("Only Project").build();
         List<Project> projects = List.of(project);
 
         // When
-        List<Project> result = projectSorter.sortByScore(projects, false);
+        List<Project> result = projectSorter.sortBy(projects, "ice");
 
         // Then
         assertEquals(1, result.size());
         assertEquals("Only Project", result.get(0).getName());
+    }
+
+    @Test
+    void describeSortKey_ShouldDescribeEverySupportedKey() {
+        // When & Then
+        assertEquals("ICE score", ProjectSorter.describeSortKey("ice"));
+        assertEquals("RICE score", ProjectSorter.describeSortKey("rice"));
+        assertEquals("name", ProjectSorter.describeSortKey("name"));
+        assertEquals("impact", ProjectSorter.describeSortKey("impact"));
+        assertEquals("effort", ProjectSorter.describeSortKey("effort"));
+    }
+
+    @Test
+    void describeSortKey_WithMixedCaseKey_ShouldDescribeAsIfLowerCase() {
+        // When & Then
+        assertEquals("ICE score", ProjectSorter.describeSortKey("IcE"));
+        assertEquals("name", ProjectSorter.describeSortKey("NAME"));
+    }
+
+    @Test
+    void describeSortKey_WithUnsupportedKey_ShouldThrowException() {
+        // When & Then
+        assertThrows(IllegalArgumentException.class, () -> ProjectSorter.describeSortKey("bogus"));
+        assertThrows(IllegalArgumentException.class, () -> ProjectSorter.describeSortKey(null));
+    }
+
+    @Test
+    void describeSortDirection_ShouldDescribeNameAlphabeticallyAndEveryOtherKeyDescending() {
+        // When & Then
+        assertEquals("A to Z", ProjectSorter.describeSortDirection("name"));
+        for (String key : ProjectSorter.getSupportedSortKeys()) {
+            if (!"name".equals(key)) {
+                assertEquals("highest to lowest", ProjectSorter.describeSortDirection(key));
+            }
+        }
+    }
+
+    @Test
+    void describeSortDirection_WithUnsupportedKey_ShouldThrowException() {
+        // When & Then
+        assertThrows(IllegalArgumentException.class, () -> ProjectSorter.describeSortDirection("bogus"));
+    }
+
+    @Test
+    void defaultSortKey_ShouldBeASupportedKey() {
+        // When & Then
+        assertEquals("ice", ProjectSorter.DEFAULT_SORT_KEY);
+        assertTrue(ProjectSorter.isSupportedSortKey(ProjectSorter.DEFAULT_SORT_KEY));
     }
 }

--- a/src/test/java/com/preponderous/parpt/integration/MarkdownExportIntegrationTest.java
+++ b/src/test/java/com/preponderous/parpt/integration/MarkdownExportIntegrationTest.java
@@ -59,7 +59,7 @@ class MarkdownExportIntegrationTest {
 
         // Export to markdown sorted by ICE
         List<Project> projects = projectService.getProjects();
-        markdownWriter.writeMarkdown(projects, false);
+        markdownWriter.writeMarkdown(projects, "ice");
 
         // Verify the markdown file was created and has correct content
         assertTrue(Files.exists(Paths.get("integration-test-projects.md")));
@@ -87,10 +87,19 @@ class MarkdownExportIntegrationTest {
         assertTrue(content.contains("Impact:** 5/5 (very high)"));
         
         // Test RICE sorting
-        markdownWriter.writeMarkdown(projects, true);
+        markdownWriter.writeMarkdown(projects, "rice");
         String riceContent = Files.readString(Paths.get("integration-test-projects.md"));
         assertTrue(riceContent.contains("Sorted by RICE score"));
-        
+
+        // Test sorting by a non-score field
+        markdownWriter.writeMarkdown(projects, "name");
+        String nameContent = Files.readString(Paths.get("integration-test-projects.md"));
+        assertTrue(nameContent.contains("Sorted by name (A to Z)"));
+        assertTrue(nameContent.indexOf("High Impact App") < nameContent.indexOf("Quick Win Feature"),
+                "High Impact App should come before Quick Win Feature when sorted by name");
+        assertTrue(nameContent.indexOf("Quick Win Feature") < nameContent.indexOf("Technical Debt Fix"),
+                "Quick Win Feature should come before Technical Debt Fix when sorted by name");
+
         // Clean up
         Files.deleteIfExists(Paths.get("integration-test-projects.json"));
         Files.deleteIfExists(Paths.get("integration-test-projects.md"));

--- a/src/test/java/com/preponderous/parpt/repo/ProjectMarkdownWriterImplTest.java
+++ b/src/test/java/com/preponderous/parpt/repo/ProjectMarkdownWriterImplTest.java
@@ -52,12 +52,12 @@ class ProjectMarkdownWriterImplTest {
         List<Project> projects = List.of(project);
         List<Project> sortedProjects = List.of(project);
 
-        when(markdownFormatter.formatHeader(false)).thenReturn("# Project Priorities\n\n");
-        when(projectSorter.sortByScore(projects, false)).thenReturn(sortedProjects);
+        when(markdownFormatter.formatHeader("ice")).thenReturn("# Project Priorities\n\n");
+        when(projectSorter.sortBy(projects, "ice")).thenReturn(sortedProjects);
         when(markdownFormatter.formatProject(project, 1)).thenReturn("## 1. Test Project\n");
 
         // When
-        markdownWriter.writeMarkdown(projects, false);
+        markdownWriter.writeMarkdown(projects, "ice");
 
         // Then
         assertTrue(Files.exists(tempMarkdownFile));
@@ -65,8 +65,8 @@ class ProjectMarkdownWriterImplTest {
         assertTrue(content.contains("# Project Priorities"));
         assertTrue(content.contains("## 1. Test Project"));
         
-        verify(markdownFormatter).formatHeader(false);
-        verify(projectSorter).sortByScore(projects, false);
+        verify(markdownFormatter).formatHeader("ice");
+        verify(projectSorter).sortBy(projects, "ice");
         verify(markdownFormatter).formatProject(project, 1);
     }
 
@@ -78,16 +78,16 @@ class ProjectMarkdownWriterImplTest {
         List<Project> projects = Arrays.asList(project1, project2);
         List<Project> sortedProjects = Arrays.asList(project2, project1);
 
-        when(markdownFormatter.formatHeader(true)).thenReturn("# Header\n");
-        when(projectSorter.sortByScore(projects, true)).thenReturn(sortedProjects);
+        when(markdownFormatter.formatHeader("rice")).thenReturn("# Header\n");
+        when(projectSorter.sortBy(projects, "rice")).thenReturn(sortedProjects);
         when(markdownFormatter.formatProject(any(), anyInt())).thenReturn("## Project\n");
 
         // When
-        markdownWriter.writeMarkdown(projects, true);
+        markdownWriter.writeMarkdown(projects, "rice");
 
         // Then
-        verify(projectSorter).sortByScore(projects, true);
-        verify(markdownFormatter).formatHeader(true);
+        verify(projectSorter).sortBy(projects, "rice");
+        verify(markdownFormatter).formatHeader("rice");
         verify(markdownFormatter).formatProject(project2, 1);
         verify(markdownFormatter).formatProject(project1, 2);
     }
@@ -99,16 +99,16 @@ class ProjectMarkdownWriterImplTest {
         List<Project> projects = List.of(project);
         List<Project> sortedProjects = List.of(project);
 
-        when(markdownFormatter.formatHeader(true)).thenReturn("# Header RICE\n");
-        when(projectSorter.sortByScore(projects, true)).thenReturn(sortedProjects);
+        when(markdownFormatter.formatHeader("rice")).thenReturn("# Header RICE\n");
+        when(projectSorter.sortBy(projects, "rice")).thenReturn(sortedProjects);
         when(markdownFormatter.formatProject(project, 1)).thenReturn("## Project\n");
 
         // When
-        markdownWriter.writeMarkdown(projects, true);
+        markdownWriter.writeMarkdown(projects, "rice");
 
         // Then
-        verify(markdownFormatter).formatHeader(true);
-        verify(projectSorter).sortByScore(projects, true);
+        verify(markdownFormatter).formatHeader("rice");
+        verify(projectSorter).sortBy(projects, "rice");
         
         String content = Files.readString(tempMarkdownFile);
         assertTrue(content.contains("# Header RICE"));
@@ -118,28 +118,43 @@ class ProjectMarkdownWriterImplTest {
     void writeMarkdown_WithEmptyList_ShouldWriteNoProjectsMessage() throws IOException {
         // Given
         List<Project> projects = List.of();
-        when(markdownFormatter.formatHeader(false)).thenReturn("# Header\n");
+        when(markdownFormatter.formatHeader("ice")).thenReturn("# Header\n");
+        when(projectSorter.sortBy(projects, "ice")).thenReturn(List.of());
         when(markdownFormatter.formatNoProjectsMessage()).thenReturn("No projects found.\n");
 
         // When
-        markdownWriter.writeMarkdown(projects, false);
+        markdownWriter.writeMarkdown(projects, "ice");
 
         // Then
         String content = Files.readString(tempMarkdownFile);
         assertTrue(content.contains("# Header"));
         assertTrue(content.contains("No projects found"));
-        
-        verify(markdownFormatter).formatHeader(false);
+
+        verify(markdownFormatter).formatHeader("ice");
         verify(markdownFormatter).formatNoProjectsMessage();
-        verify(projectSorter, never()).sortByScore(any(), anyBoolean());
         verify(markdownFormatter, never()).formatProject(any(), anyInt());
+    }
+
+    @Test
+    void writeMarkdown_WithUnsupportedSortKey_ShouldThrowBeforeWritingTheFile() {
+        // Given
+        List<Project> projects = List.of(Project.builder().name("Test Project").build());
+        when(projectSorter.sortBy(projects, "bogus"))
+                .thenThrow(new IllegalArgumentException("Unsupported sort key: bogus"));
+
+        // When & Then
+        assertThrows(IllegalArgumentException.class,
+                () -> markdownWriter.writeMarkdown(projects, "bogus"));
+
+        assertFalse(Files.exists(tempMarkdownFile));
+        verifyNoInteractions(markdownFormatter);
     }
 
     @Test
     void writeMarkdown_WithNullList_ShouldThrowException() {
         // When & Then
         assertThrows(IllegalArgumentException.class, 
-                () -> markdownWriter.writeMarkdown(null, false));
+                () -> markdownWriter.writeMarkdown(null, "ice"));
         
         verifyNoInteractions(markdownFormatter);
         verifyNoInteractions(projectSorter);
@@ -155,12 +170,12 @@ class ProjectMarkdownWriterImplTest {
         List<Project> projects = Arrays.asList(project1, project2, project3);
         List<Project> sortedProjects = Arrays.asList(project3, project1, project2);
 
-        when(markdownFormatter.formatHeader(false)).thenReturn("# Header\n");
-        when(projectSorter.sortByScore(projects, false)).thenReturn(sortedProjects);
+        when(markdownFormatter.formatHeader("ice")).thenReturn("# Header\n");
+        when(projectSorter.sortBy(projects, "ice")).thenReturn(sortedProjects);
         when(markdownFormatter.formatProject(any(), anyInt())).thenReturn("## Project\n");
 
         // When
-        markdownWriter.writeMarkdown(projects, false);
+        markdownWriter.writeMarkdown(projects, "ice");
 
         // Then
         verify(markdownFormatter).formatProject(project3, 1);


### PR DESCRIPTION
## Summary

- The boolean-flag `ProjectSorter.sortByScore(List, boolean)` path has been removed, so comparator selection is no longer duplicated between it and the key-based `sortBy(List, String)` API added for the `list` command. `sortByIce` and `sortByRice` have been kept as thin delegating wrappers onto `sortBy`, which preserves their existing test coverage while leaving a single comparator-selection site.
- Sort-key vocabulary has been given a single owner: `ProjectSorter.DEFAULT_SORT_KEY`, `ProjectSorter.describeSortKey` (e.g. `"ICE score"`, `"name"`) and `ProjectSorter.describeSortDirection` (`"A to Z"` / `"highest to lowest"`) have been added and are consumed by both the export command and the markdown header.
- `ProjectMarkdownWriter.writeMarkdown` and `MarkdownFormatter.formatHeader` now take a sort key rather than a boolean. As a side effect, every sort key is now available to `export --sort`, not only `ice` and `rice`.
- Sorting is now performed before the output file is opened, so an unsupported sort key is rejected before `projects.md` is truncated. Previously an invalid key could only have been surfaced after the header had already been written.
- `export --sort` is validated with `ProjectSorter.isSupportedSortKey`, reusing the error-message shape the `list` command uses (`Invalid sort option. Use one of: name, impact, confidence, ease, reach, effort, ice, rice.`).
- The `sortByScore` test coverage has been migrated onto `sortBy` rather than deleted, and coverage has been added for the new description helpers, for a name-sorted export end to end, and for the unsupported-key-before-write behavior.
- The README Features list, command list and Export Examples block have been updated to describe the wider set of `export --sort` values.

## Behavior notes

- `export` and `export --sort rice` are unchanged for users; the emitted header text for those keys is byte-identical to before.
- `export` still always sorts (defaulting to ICE), which differs from `list`, where omitting `--sort` keeps creation order. This difference has been documented in the README rather than changed, since altering it would change existing export behavior beyond the scope of this issue.

## Test plan

- [x] `./gradlew compileJava` — BUILD SUCCESSFUL
- [x] `./gradlew test` — BUILD SUCCESSFUL, 87 tests, 0 failures
- [x] End-to-end markdown export verified for `ice`, `rice` and `name` keys in `MarkdownExportIntegrationTest`

## Scope

Eleven files were modified, one over the ten-file soft ceiling; five of the eleven are test files and the non-test net change is well under the LOC ceiling. The remaining open issues (#37, #36, #33, #32, #27, #21, #20, #8) were deferred because this cycle was scoped to a single coherent refactor of the export sorting path; none of them touch it.

Closes #43

This PR description was drafted during a Gardener session (https://github.com/Stephenson-Software/gardener).

<!-- gardener-tend-dispatch -->

---

_drafted by Claude on behalf of Daniel Stephenson_